### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,7 @@
     "javascript",
     "library"
   ],
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/adriancmiranda/sprite.js/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/adriancmiranda/sprite.js.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
